### PR TITLE
add auth & tasks services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,40 @@
+networks:
+    async_arch_edu:
+        name: async_arch_edu
+
+volumes:
+    dbdata:
+        name: async_arch_edu_mysql_data
+    rabbit_data:
+        name: async_arch_edu_rabbit_data
+
+services:
+    mysql:
+        image: mysql:8.0
+        container_name: async_arch_edu_mysql
+        command: --default-authentication-plugin=mysql_native_password
+        env_file: .env
+        volumes:
+            - dbdata:/var/lib/mysql
+        environment:
+            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+            MYSQL_DATABASE: ${DB_DATABASE}
+            MYSQL_USER: ${DB_USERNAME}
+            MYSQL_PASSWORD: ${DB_PASSWORD}
+        ports:
+            - ${DB_PORT}:3306
+        networks:
+            async_arch_edu:
+    rabbit:
+        image: rabbitmq:3.8-management
+        hostname: rabbit
+        environment:
+            RABBITMQ_ERLANG_COOKIE: ${RABBITMQ_ERLANG_COOKIE}
+            RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME}
+            RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+            RABBITMQ_DEFAULT_VHOST: /
+        ports:
+            - ${RABBITMQ_MANAGEMENT_PORT}:15672
+            - ${RABBITMQ_PORT}:5672
+        volumes:
+            - rabbit_data:/var/lib/rabbitmq/mnesia/

--- a/src/auth_service/env.ts
+++ b/src/auth_service/env.ts
@@ -1,0 +1,24 @@
+import { cleanEnv, host, num, str } from "envalid"
+
+const env = cleanEnv(process.env, {
+  NODE_ENV: str({ default: "development", choices: [
+    "production",
+    "development",
+    "test",
+  ] }),
+  AUTH_SERVICE_PORT: num(),
+  TASKS_SERVICE_PORT: num(),
+  DB_CONNECTION: str({ choices: ["mysql", "mariadb", "postgres", "mssql"] }),
+  DB_HOST: host(),
+  DB_PORT: num(),
+  DB_DATABASE: str(),
+  DB_USERNAME: str(),
+  DB_PASSWORD: str(),
+  JWT_SECRET: str(),
+  RABBITMQ_HOST: str(),
+  RABBITMQ_PORT: num(),
+  RABBITMQ_USERNAME: str(),
+  RABBITMQ_PASSWORD: str(),
+})
+
+export { env }

--- a/src/auth_service/index.ts
+++ b/src/auth_service/index.ts
@@ -1,0 +1,40 @@
+import "dotenv/config"
+import bodyParser from "body-parser"
+import express from "express"
+import { expressjwt } from "express-jwt"
+
+import { authRouter, proxyRouter } from "@auth/routes"
+import { db, initMessageBroker } from "@auth/services"
+import { env } from "@auth/env"
+import { expressErrorHandler } from "@common/handlers"
+
+const port = env.AUTH_SERVICE_PORT
+const unprotectedRoutes = ["/auth/signup", "/auth/login"]
+
+const initApp = async () => {
+  try {
+    Promise.all([
+      await db.authenticate().then(() => db.sync()),
+      await initMessageBroker(),
+    ])
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
+  const app = express()
+
+  app.use(bodyParser.json())
+
+  app.use(expressjwt({ secret: env.JWT_SECRET, algorithms: ["HS256"] })
+    .unless({ path: unprotectedRoutes }))
+
+  app.use("/auth", authRouter)
+  app.use(proxyRouter)
+
+  app.use(expressErrorHandler)
+
+  app.listen(port, () => console.log(`Server started on port ${port}`))
+}
+
+initApp()

--- a/src/auth_service/models/User.ts
+++ b/src/auth_service/models/User.ts
@@ -1,0 +1,46 @@
+import { DataTypes, Model } from "sequelize"
+
+import { USER_ROLES } from "@common/constants"
+import { db } from "@auth/services"
+
+class User extends Model {
+  declare publicId: string
+  declare role: string
+  declare email: string
+  declare passwordHash: string
+  declare salt: string
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  publicId: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+  },
+  role: {
+    type: DataTypes.STRING,
+    defaultValue: USER_ROLES.user,
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  passwordHash: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  salt: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  sequelize: db,
+  tableName: "auth_Users",
+})
+
+export { User }

--- a/src/auth_service/models/index.ts
+++ b/src/auth_service/models/index.ts
@@ -1,0 +1,1 @@
+export * from "./User"

--- a/src/auth_service/routes/auth.ts
+++ b/src/auth_service/routes/auth.ts
@@ -1,0 +1,100 @@
+import asyncHandler from "express-async-handler"
+import crypto from "crypto"
+import express from "express"
+import nJwt from "njwt"
+import { promisify } from "util"
+import secureRandom from "secure-random"
+
+import {
+  EVENT_NAMES,
+  EVENT_TYPES,
+  MB_EXCHANGES,
+  USER_ROLES,
+} from "@common/constants"
+import { User } from "@auth/models"
+import type { UserCreatedCudEvent } from "@common/contracts"
+import { env } from "@auth/env"
+import { messageBroker } from "@auth/services"
+
+const authRouter = express.Router()
+const pbkdf2 = promisify(crypto.pbkdf2)
+const generatePassword = (
+  password: crypto.BinaryLike,
+  salt: crypto.BinaryLike,
+) => pbkdf2.call(null, password, salt, 310000, 32, "sha256")
+
+authRouter.post("/signup", asyncHandler(async (req, res) => {
+  const { email, password } = req.body
+
+  const salt = secureRandom(16, { type: "Buffer" })
+  const passwordHash = await generatePassword(password, salt)
+    .then(buf => buf.toString("hex"))
+
+  const user = await User.create({
+    email,
+    passwordHash,
+    salt: salt.toString("hex"),
+  })
+
+  user.toJSON()
+
+  const dataToStream: UserCreatedCudEvent = {
+    meta: {
+      name: EVENT_NAMES.user_created,
+      type: EVENT_TYPES.cud,
+    },
+    data: {
+      publicId: user.publicId,
+      email: user.email,
+      role: user.role as USER_ROLES,
+    },
+  }
+
+  messageBroker.publishEvent(MB_EXCHANGES.cud_user, dataToStream)
+
+  res.status(201).json({ result: "ok" })
+}))
+
+authRouter.post("/login", asyncHandler(async (req, res) => {
+  const { email, password } = req.body
+
+  const user = await User.findOne({ where: { email } })
+
+  if (!user) {
+    res.status(422).json({
+      result: "error",
+      message: "Email or password are incorrect",
+    })
+    return
+  }
+
+  const passwordHash = await generatePassword(
+    password,
+    Buffer.from(user.salt, "hex"),
+  )
+
+  const doesPasswordsMatch = crypto.timingSafeEqual(
+    Buffer.from(user.passwordHash, "hex"),
+    passwordHash,
+  )
+
+  if (!doesPasswordsMatch) {
+    res.status(422).json({
+      result: "error",
+      message: "Email or password are incorrect",
+    })
+    return
+  }
+
+  const claims = {
+    sub: user.publicId,
+    scope: user.role,
+  }
+
+  const token = nJwt.create(claims, env.JWT_SECRET)
+  token.setExpiration(Date.now() + (1000 * 60 * 15))
+
+  res.json({ result: "ok", token: token.compact() })
+}))
+
+export { authRouter }

--- a/src/auth_service/routes/index.ts
+++ b/src/auth_service/routes/index.ts
@@ -1,0 +1,2 @@
+export * from "./auth"
+export * from "./proxy"

--- a/src/auth_service/routes/proxy.ts
+++ b/src/auth_service/routes/proxy.ts
@@ -1,0 +1,37 @@
+import type { Request } from "express-jwt"
+import asyncHandler from "express-async-handler"
+import axios from "axios"
+import express from "express"
+
+import { env } from "@auth/env"
+
+const servicesToPorts: Record<string, number> = {
+  tasks: env.TASKS_SERVICE_PORT,
+}
+
+const proxyRouter = express.Router()
+
+proxyRouter.all(/.*/, asyncHandler(async (req: Request, res) => {
+  const service = req.path.match(/\/(.*?)\//)?.[1]
+
+  if (!service) {
+    throw new Error("Route not found")
+  }
+
+  const port = servicesToPorts[service]
+
+  const options = {
+    url: `http://localhost:${port}${req.path}`,
+    method: req.method,
+    data: {
+      ...req.body,
+      callerId: req.auth.sub,
+      callerRole: req.auth.scope,
+    },
+  }
+
+  const { data } = await axios.request(options)
+  res.json(data)
+}))
+
+export { proxyRouter }

--- a/src/auth_service/services/db.ts
+++ b/src/auth_service/services/db.ts
@@ -1,0 +1,20 @@
+import { Sequelize } from "sequelize"
+import { env } from "@auth/env"
+
+const {
+  DB_CONNECTION,
+  DB_HOST,
+  DB_PORT,
+  DB_DATABASE,
+  DB_USERNAME,
+  DB_PASSWORD,
+} = env
+
+const db = new Sequelize(DB_DATABASE, DB_USERNAME, DB_PASSWORD, {
+  host: DB_HOST,
+  port: DB_PORT,
+  dialect: DB_CONNECTION,
+  logging: false,
+})
+
+export { db }

--- a/src/auth_service/services/index.ts
+++ b/src/auth_service/services/index.ts
@@ -1,0 +1,2 @@
+export * from "./db"
+export * from "./messageBroker"

--- a/src/auth_service/services/messageBroker.ts
+++ b/src/auth_service/services/messageBroker.ts
@@ -1,0 +1,18 @@
+import { MB_EXCHANGES } from "@common/constants"
+import { RabbitMQ } from "@common/rabbitMQ"
+import { env } from "@auth/env"
+
+const messageBroker = new RabbitMQ({
+  hostname: env.RABBITMQ_HOST,
+  port: env.RABBITMQ_PORT,
+  username: env.RABBITMQ_USERNAME,
+  password: env.RABBITMQ_PASSWORD,
+})
+
+const initMessageBroker = async () => {
+  await messageBroker.init()
+
+  await messageBroker.assertExchange(MB_EXCHANGES.cud_user, "fanout")
+}
+
+export { messageBroker, initMessageBroker }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,26 @@
+const enum USER_ROLES {
+  user = "user",
+  manager = "manager",
+  admin = "admin",
+}
+
+const enum MB_EXCHANGES {
+  cud_user = "cud_user",
+  cud_tasks = "cud_tasks",
+  be_tasks = "be_tasks",
+}
+
+const enum EVENT_TYPES {
+  cud,
+  business,
+}
+
+const enum EVENT_NAMES {
+  user_created = "user_created",
+  task_added = "task_added",
+  task_created = "task_created",
+  task_completed = "task_completed",
+  tasks_reassigned = "tasks_reassigned",
+}
+
+export { USER_ROLES, MB_EXCHANGES, EVENT_TYPES, EVENT_NAMES }

--- a/src/common/contracts.ts
+++ b/src/common/contracts.ts
@@ -1,0 +1,52 @@
+import type { EVENT_TYPES, USER_ROLES } from "./constants"
+
+interface Event {
+  meta: {
+    name: string
+    type: EVENT_TYPES
+  }
+  data: unknown
+}
+
+interface UserCreatedCudEvent extends Event {
+  data: {
+    publicId: string
+    email: string
+    role: USER_ROLES
+  }
+}
+
+interface TaskAddedBeEvent extends Event {
+  data: {
+    publicId: string
+    assignedTo: string
+  }
+}
+
+interface TaskCompletedBeEvent extends Event {
+  data: {
+    publicId: string
+  }
+}
+
+interface TasksReassignedBeEvent extends Event {
+  data: {
+    publicIds: string[]
+  }
+}
+
+interface TaskCreatedCudEvent extends Event {
+  data: {
+    publicId: string
+    description: string
+  }
+}
+
+export {
+  Event,
+  UserCreatedCudEvent,
+  TaskAddedBeEvent,
+  TaskCompletedBeEvent,
+  TasksReassignedBeEvent,
+  TaskCreatedCudEvent,
+}

--- a/src/common/handlers.ts
+++ b/src/common/handlers.ts
@@ -1,0 +1,35 @@
+import { AxiosError } from "axios"
+import type { ErrorRequestHandler } from "express"
+
+const expressErrorHandler: ErrorRequestHandler = ((err, _req, res, _next) => {
+  if (err instanceof AxiosError && err.response) {
+    const axRes = err.response
+    delete axRes.request
+    console.error(axRes)
+
+    return res.status(502).json({
+      result: "error",
+      message: axRes.statusText,
+    })
+  }
+
+  if (err instanceof AxiosError) {
+    delete err.request
+  }
+
+  console.error(err)
+
+  if (err.message === "Route not found") {
+    return res.status(404).json({
+      result: "error",
+      message: err.message,
+    })
+  }
+
+  return res.status(500).json({
+    result: "error",
+    message: err.message,
+  })
+})
+
+export { expressErrorHandler }

--- a/src/common/rabbitMQ.ts
+++ b/src/common/rabbitMQ.ts
@@ -1,0 +1,51 @@
+import rabbitmq, { Channel } from "amqplib"
+
+class RabbitMQ {
+  channel!: Channel
+
+  constructor(private authData: {
+    hostname: string,
+    port: number,
+    username: string,
+    password: string
+  }) { }
+
+  async init() {
+    const { hostname, port, username, password } = this.authData
+
+    const connection = await rabbitmq.connect({
+      hostname,
+      port,
+      username,
+      password,
+    })
+    this.channel = await connection.createChannel()
+  }
+
+  async assertExchange(name: string, type: string) {
+    await this.channel.assertExchange(name, type)
+  }
+
+  async assertQueue(queue: string) {
+    await this.channel.assertQueue(queue)
+  }
+
+  async bindQueue(queue: string, exchange: string, pattern = "") {
+    await this.channel.bindQueue(queue, exchange, pattern)
+  }
+
+  publishEvent(exchange: string, data: object, routingKey = "") {
+    const content = Buffer.from(JSON.stringify(data))
+
+    this.channel.publish(exchange, routingKey, content)
+  }
+
+  consumeEvent(
+    queue: string,
+    cb: (msg: rabbitmq.ConsumeMessage | null) => void,
+  ) {
+    this.channel.consume(queue, cb)
+  }
+}
+
+export { RabbitMQ }

--- a/src/tasks_service/env.ts
+++ b/src/tasks_service/env.ts
@@ -1,0 +1,22 @@
+import { cleanEnv, host, num, str } from "envalid"
+
+const env = cleanEnv(process.env, {
+  NODE_ENV: str({ default: "development", choices: [
+    "production",
+    "development",
+    "test",
+  ] }),
+  TASKS_SERVICE_PORT: num(),
+  DB_CONNECTION: str({ choices: ["mysql", "mariadb", "postgres", "mssql"] }),
+  DB_HOST: host(),
+  DB_PORT: num(),
+  DB_DATABASE: str(),
+  DB_USERNAME: str(),
+  DB_PASSWORD: str(),
+  RABBITMQ_HOST: str(),
+  RABBITMQ_PORT: num(),
+  RABBITMQ_USERNAME: str(),
+  RABBITMQ_PASSWORD: str(),
+})
+
+export { env }

--- a/src/tasks_service/helpers/index.ts
+++ b/src/tasks_service/helpers/index.ts
@@ -1,0 +1,5 @@
+const getRandomArrEl = <T>(arr: T[]) => {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+export { getRandomArrEl }

--- a/src/tasks_service/index.ts
+++ b/src/tasks_service/index.ts
@@ -1,0 +1,34 @@
+import "dotenv/config"
+import bodyParser from "body-parser"
+import express from "express"
+
+import { db, initMessageBroker } from "@tasks/services"
+import { env } from "@tasks/env"
+import { expressErrorHandler } from "@common/handlers"
+import { tasksRouter } from "@tasks/routes"
+
+const port = env.TASKS_SERVICE_PORT
+
+const initApp = async () => {
+  try {
+    Promise.all([
+      await db.authenticate().then(() => db.sync()),
+      await initMessageBroker(),
+    ])
+  } catch (err) {
+    console.error(err)
+    return
+  }
+
+  const app = express()
+
+  app.use(bodyParser.json())
+
+  app.use("/tasks", tasksRouter)
+
+  app.use(expressErrorHandler)
+
+  app.listen(port, () => console.log(`Server started on port ${port}`))
+}
+
+initApp()

--- a/src/tasks_service/models/Task.ts
+++ b/src/tasks_service/models/Task.ts
@@ -1,0 +1,55 @@
+import { DataTypes, Model, ModelStatic } from "sequelize"
+
+import { db } from "@tasks/services"
+
+class Task extends Model {
+  declare id: number
+  declare publicId: string
+  declare assignedTo: string
+  declare description: string
+  declare isCompleted: boolean
+
+  static associate(models: Record<string, ModelStatic<Model>>) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    Task.belongsTo(models["User"]!, {
+      foreignKey: "assignedTo",
+      as: "assignedUser",
+    })
+  }
+}
+
+Task.init({
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  publicId: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+  },
+  assignedTo: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: {
+        tableName: "tasks_Users",
+      },
+      key: "publicId",
+    },
+  },
+  description: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  },
+  isCompleted: {
+    type: DataTypes.BOOLEAN,
+    defaultValue: false,
+  },
+}, {
+  sequelize: db,
+  tableName: "tasks_Tasks",
+})
+
+export { Task }

--- a/src/tasks_service/models/User.ts
+++ b/src/tasks_service/models/User.ts
@@ -1,0 +1,44 @@
+import { DataTypes, Model, ModelStatic } from "sequelize"
+
+import { db } from "@tasks/services"
+
+class User extends Model {
+  declare id: number
+  declare publicId: string
+  declare email: string
+  declare role: string
+
+  static associate(models: Record<string, ModelStatic<Model>>) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.hasMany(models["Task"]!, {
+      foreignKey: "assignedTo",
+      as: "tasks",
+    })
+  }
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  publicId: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    unique: true,
+  },
+  role: {
+    type: DataTypes.STRING,
+    defaultValue: "user",
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+}, {
+  sequelize: db,
+  tableName: "tasks_Users",
+})
+
+export { User }

--- a/src/tasks_service/models/index.ts
+++ b/src/tasks_service/models/index.ts
@@ -1,0 +1,2 @@
+export * from "./User"
+export * from "./Task"

--- a/src/tasks_service/routes/index.ts
+++ b/src/tasks_service/routes/index.ts
@@ -1,0 +1,1 @@
+export * from "./tasks"

--- a/src/tasks_service/routes/tasks.ts
+++ b/src/tasks_service/routes/tasks.ts
@@ -1,0 +1,153 @@
+import express from "express"
+
+import {
+  EVENT_NAMES,
+  EVENT_TYPES,
+  MB_EXCHANGES,
+  USER_ROLES,
+} from "@common/constants"
+import { Task, User } from "@tasks/models"
+import type {
+  TaskAddedBeEvent,
+  TaskCompletedBeEvent,
+  TaskCreatedCudEvent,
+  TasksReassignedBeEvent,
+} from "@common/contracts"
+import expressAsyncHandler from "express-async-handler"
+import { getRandomArrEl } from "@tasks/helpers"
+import { messageBroker } from "@tasks/services"
+
+const tasksRouter = express.Router()
+
+tasksRouter.post("/create", expressAsyncHandler(async (req, res) => {
+  const { description, userPublicId, callerId, callerRole } = req.body
+
+  const assignedTo = callerRole === USER_ROLES.user ? callerId : userPublicId
+
+  const task = await Task.create({ description, assignedTo })
+
+  {
+    const dataToStream: TaskAddedBeEvent = {
+      meta: {
+        name: EVENT_NAMES.task_added,
+        type: EVENT_TYPES.business,
+      },
+      data: {
+        publicId: task.publicId,
+        assignedTo: task.assignedTo,
+      },
+    }
+
+    messageBroker.publishEvent(MB_EXCHANGES.be_tasks, dataToStream)
+  }
+
+  {
+    const dataToStream: TaskCreatedCudEvent = {
+      meta: {
+        name: EVENT_NAMES.task_created,
+        type: EVENT_TYPES.cud,
+      },
+      data: {
+        publicId: task.publicId,
+        description: task.description,
+      },
+    }
+
+    messageBroker.publishEvent(MB_EXCHANGES.cud_tasks, dataToStream)
+  }
+
+  res.status(201).json({
+    result: "ok",
+    data: task,
+  })
+}))
+
+tasksRouter.post("/complete", expressAsyncHandler(async (req, res) => {
+  const { taskId, callerId } = req.body
+
+  const task = await Task.findOne({ where: { publicId: taskId } })
+
+  if (!task) {
+    res.status(404).json({
+      result: "error",
+      message: "Task not found",
+    })
+    return
+  }
+
+  if (task.assignedTo !== callerId) {
+    res.status(401).json({
+      result: "error",
+      message: "You don't have access to this task",
+    })
+    return
+  }
+
+  await task.update({ isCompleted: true })
+
+  const dataToStream: TaskCompletedBeEvent = {
+    meta: {
+      name: EVENT_NAMES.task_completed,
+      type: EVENT_TYPES.business,
+    },
+    data: {
+      publicId: task.publicId,
+    },
+  }
+
+  messageBroker.publishEvent(MB_EXCHANGES.be_tasks, dataToStream)
+
+  res.json({ result: "ok" })
+}))
+
+tasksRouter.post("/reassign", expressAsyncHandler(async (req, res) => {
+  const { callerRole } = req.body
+
+  if (callerRole === USER_ROLES.user) {
+    res.status(401).json({
+      result: "error",
+      message: "You don't have access to this route",
+    })
+    return
+  }
+
+  const [ users, tasks ] = await Promise.all([
+    User.findAll({
+      where: { role: USER_ROLES.user },
+      attributes: ["publicId"],
+    }),
+    Task.findAll({
+      where: { isCompleted: false },
+      attributes: ["id", "publicId", "assignedTo"] }),
+  ])
+
+  if (users.length === 0) {
+    res.status(500).json({
+      result: "error",
+      message: "No users found in DB",
+    })
+    return
+  }
+
+  await Promise.all(tasks.map(task => {
+    const randomUser = getRandomArrEl(users) as User
+
+    return task.update({ assignedTo: randomUser.publicId })
+  }))
+
+  const dataToStream: TasksReassignedBeEvent = {
+    meta: {
+      name: EVENT_NAMES.task_completed,
+      type: EVENT_TYPES.business,
+    },
+    data: {
+      publicIds: tasks.map(task => task.publicId),
+    },
+  }
+
+  messageBroker.publishEvent(MB_EXCHANGES.be_tasks, dataToStream)
+
+  res.json({ result: "ok" })
+}))
+
+export { tasksRouter }

--- a/src/tasks_service/services/db.ts
+++ b/src/tasks_service/services/db.ts
@@ -1,0 +1,20 @@
+import { Sequelize } from "sequelize"
+import { env } from "@tasks/env"
+
+const {
+  DB_CONNECTION,
+  DB_HOST,
+  DB_PORT,
+  DB_DATABASE,
+  DB_USERNAME,
+  DB_PASSWORD,
+} = env
+
+const db = new Sequelize(DB_DATABASE, DB_USERNAME, DB_PASSWORD, {
+  host: DB_HOST,
+  port: DB_PORT,
+  dialect: DB_CONNECTION,
+  logging: false,
+})
+
+export { db }

--- a/src/tasks_service/services/index.ts
+++ b/src/tasks_service/services/index.ts
@@ -1,0 +1,2 @@
+export * from "./db"
+export * from "./messageBroker"

--- a/src/tasks_service/services/messageBroker.ts
+++ b/src/tasks_service/services/messageBroker.ts
@@ -1,0 +1,49 @@
+import type { ConsumeMessage } from "amqplib"
+
+import { EVENT_NAMES, MB_EXCHANGES } from "@common/constants"
+import type { Event, UserCreatedCudEvent } from "@common/contracts"
+import { RabbitMQ } from "@common/rabbitMQ"
+import { User } from "@tasks/models"
+import { env } from "@tasks/env"
+
+const messageBroker = new RabbitMQ({
+  hostname: env.RABBITMQ_HOST,
+  port: env.RABBITMQ_PORT,
+  username: env.RABBITMQ_USERNAME,
+  password: env.RABBITMQ_PASSWORD,
+})
+
+const queueName = `${MB_EXCHANGES.cud_user}_to_tasks`
+
+const isUserCreatedCudEvent = (event: Event): event is UserCreatedCudEvent => {
+  return event.meta.name === EVENT_NAMES.user_created
+}
+
+const initMessageBroker = async () => {
+  await messageBroker.init()
+
+  await messageBroker.assertExchange(MB_EXCHANGES.be_tasks, "fanout")
+  await messageBroker.assertExchange(MB_EXCHANGES.cud_tasks, "fanout")
+
+  await messageBroker.assertQueue(queueName)
+  await messageBroker.bindQueue(queueName, MB_EXCHANGES.cud_user)
+
+  messageBroker.consumeEvent(
+    queueName,
+    async function (this: typeof messageBroker, msg: ConsumeMessage | null) {
+      if (msg) {
+        const content = JSON.parse(msg.content.toString()) as Event
+
+        if (isUserCreatedCudEvent(content)) {
+          await User.upsert(content.data)
+        } else {
+          console.warn("Received unhandled message: ", JSON.stringify(msg))
+
+        }
+        this.channel.ack(msg)
+      }
+    }.bind(messageBroker),
+  )
+}
+
+export { messageBroker, initMessageBroker }


### PR DESCRIPTION
Стэк: Node.js, TypeScript, MySQL.

Фронтенда нет, только API.

В качестве messageBroker RabbitMQ.

Писал на простом фреймворке (Express), поэтому контроллеры от логики не отсоединены.

Авторизацию сделал через простой JWT (без refresh) в рамках API gateway (auth_service).

Логика подписки на события находится в `src/tasks_service/services/messageBroker.ts`. Логика отправки событий в `src/auth_service/routes/auth.ts` и `src/tasks_service/routes/tasks.ts`.

Не успел сделать обычные REST-роуты, сделал только те, что нужны по условиям ДЗ.

@f213, @davydovanton